### PR TITLE
Fix Twitter and GitHub links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Greg Boone
-email: boone.greg@gmail.com	
+email: boone.greg@gmail.com
 description: "Learning out loud in Washington, DC"
 baseurl: ""
 url: "http://gboone.github.io"
@@ -9,3 +9,7 @@ timezone: "America/New_York"
 # Build settings
 markdown: kramdown
 permalink: pretty
+
+# social
+twitter: gboone42
+github: gboone

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
     <div class="footer-col-2 column">
       <ul>
         <li>
-          <a href="https://github.com/{{ site.username }}">
+          <a href="https://github.com/{{ site.github }}">
             <span class="icon github">
               <svg version="1.1" class="github-icon-svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
                  viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
@@ -29,11 +29,11 @@
                 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/>
               </svg>
             </span>
-            <span class="username">{{ site.username }}</span>
+            <span class="username">{{ site.github }}</span>
           </a>
         </li>
         <li>
-          <a href="https://twitter.com/{{ site.username }}">
+          <a href="https://twitter.com/{{ site.twitter }}">
             <span class="icon twitter">
               <svg version="1.1" class="twitter-icon-svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
                  viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
@@ -46,7 +46,7 @@
                 c6.015,0,9.304-4.983,9.304-9.304c0-0.142-0.003-0.283-0.009-0.423C14.976,4.29,15.531,3.714,15.969,3.058z"/>
               </svg>
             </span>
-            <span class="username">{{ site.username }}</span>
+            <span class="username">{{ site.twitter }}</span>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
On the live site right now:

![screenshot from 2015-03-04 22 03 46](https://cloud.githubusercontent.com/assets/4592/6498475/58649d1a-c2ba-11e4-97f2-fea344990ce9.png)

And the links just go to github.com and twitter.com. This fixes them to display your username and to link to your profiles.