### PR TITLE
Make 'fix my typos' go to the edit screen for that post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,8 +12,9 @@ layout: default
   {{ content }}
   <hr />
   <a href="https://github.com/gboone/gboone.github.io/issues/new">Leave a comment</a><br />
-  <a href="https://github.com/gboone/gboone.github.io/pulls/new">Fix my
+  <a href="https://github.com/gboone/gboone.github.io/edit/master/{{ page.path }}">Fix my
 typos</a>
+
   </article>
 
 </div>


### PR DESCRIPTION
Instead of going to `/pulls/new`, this jumps to the Edit link for the particular post in question.