### PR TITLE
Google Analytics privacy settings

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -62,9 +62,16 @@
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
     ga('create', 'UA-58136035-1', 'auto');
+
+    // anonymize user IPs (chops off the last IP triplet)
+    ga('set', 'anonymizeIp', true);
+
+    // forces SSL even if the page were somehow loaded over http://
+    ga('set', 'forceSSL', true);
+
     ga('send', 'pageview');
   </script>
   {% else %}


### PR DESCRIPTION
This makes all GA traffic run over HTTPS, and turns on IP anonymization (which reduces geolocation accuracy). It's what we use on 18f.gsa.gov.

In the spirit of transparency, I recently [submitted this change to MyRA](https://github.com/18F/myra/commit/bdae868e76b246d5887c6e3d8582afabca1e7478), and they observed a reduction in traffic starting on the day it was deployed. We don't know yet why that is. But this has been used all over our sites, and on the Digital Analytics Program itself, without issue.