### PR TITLE
Update site's canonical URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 # Site settings
 title: Greg Boone
-email: boone.greg@gmail.com	
+email: boone.greg@gmail.com
 description: "Learning out loud in Washington, DC"
 baseurl: ""
-url: "http://gboone.github.io"
+url: "http://greg.harmsboone.org"
 timezone: "America/New_York"
 
 # Build settings


### PR DESCRIPTION
The site's `<link rel="canonical">` tag is pointing to `gboone.github.io`, but the site is at `greg.harmsboone.org`. I think that's probably bad.